### PR TITLE
If a stream dies, you need to hit enter for omxplayer to exit

### DIFF
--- a/surveillance/worker.py
+++ b/surveillance/worker.py
@@ -15,7 +15,7 @@ def worker(name,rtsp_url,omxplayer_extra_options,coordinates,stopworker):
         if platform.system() == "Windows":
             proc=subprocess.Popen('echo this is a subprocess started with coordinates ' + str(coordinates) + '& ping 192.168.0.160 /t >NUL', shell=True)
         elif platform.system() == "Linux":
-            proc=subprocess.Popen(command_line_shlex,preexec_fn=os.setsid)
+            proc=subprocess.Popen(command_line_shlex,preexec_fn=os.setsid,stdin=subprocess.PIPE)
         else:
             proc=subprocess.Popen('echo this is a subprocess started with coordinates ' + str(coordinates), shell=True)
         return proc
@@ -49,6 +49,7 @@ def worker(name,rtsp_url,omxplayer_extra_options,coordinates,stopworker):
     proc=start_subprocess(rtsp_url,coordinates)
     while attempts < 100000 and stopworker.value == False:
         if proc.poll() != None:
+            proc.communicate(input="\n")
             proc=start_subprocess(rtsp_url,coordinates)
             attempts = attempts + 1
             #Wait for omxplayer to crash, or not


### PR DESCRIPTION
If I kill a video stream at the source, omxplayer stops the video, and after
a short while the video disappears from the screen. That omxplayer process
is still running. surveillance then logs:

2016/06/07 10:30:20 - worker - DEBUG - Starting stream cam_stream1 with commandline ['/usr/bin/omxplayer', '--live', '--timeout', '60', '--aidx', '-1', '-o', 'hdmi', 'rtsp://server:7447/camera_hash_1', '--win', '0 0 960 540']
2016/06/07 10:30:30 - worker - INFO - Trying to restartcam_stream1 attempts:1

Nothing is changed on the screen, the old omxplayer process still exists,
and the new one doesn't replace it. Logging continues to log the Free gpu
memory lines.

If I then hit "enter" in the surveillance window, the following is
displayed:

have a nice day ;)

The old omxplayer instance exists, and the new one starts.

This patch tries sending a newline to the old omxplayer subprocess
before it starts a new one. It resolves the issue for me.