### PR TITLE
First approach to implement touchscreen / mouse support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Disable rotation (as in pause rotation, as in fix the current displayed screen) 
 - If you want to stream rtsp over tcp please add `rtsp_over_tcp: true` to the stream in /etc/rpisurv.conf.
   See [example config file](https://github.com/SvenVD/rpisurv/blob/master/surveillance/conf/surveillance.yml) for an example.
   If you have a "smearing" effect this option may resolve it.
-  Note that you need a version of omxplayer which is released afer 14 March 2016 (https://github.com/popcornmix/omxplayer/pull/433) to do this.
+  Note that you need a version of omxplayer which is released after 14 March 2016 (https://github.com/popcornmix/omxplayer/pull/433) to do this.
 
 - On a raspberry pi 3 it seems the default overscan settings are not good. If full screen is not used, if you have an unused bar in the bottom -> try to set `disable_overscan=1` in /boot/config.txt
 

--- a/surveillance/conf/surveillance.yml
+++ b/surveillance/conf/surveillance.yml
@@ -33,7 +33,7 @@ essentials:
           #Default to 4 seconds
           probe_timeout: 10
           #Enable this option if you want the rtsp stream to stream over tcp instead of udp, this may solve a "smearing" effect on some setups. Defaults to false
-          #Note that you need a version of omxplayer older then 14 March 2016 for this option to work
+          #Note that you need a version of omxplayer which is released after 14 March 2016 for this option to work
           rtsp_over_tcp: true
           #Foscam-fi9821w example
         - url: "rtsp://<user>:<password>@<ip or dnsname>:<port>/videoMain"

--- a/surveillance/core/util/draw.py
+++ b/surveillance/core/util/draw.py
@@ -53,6 +53,19 @@ def check_keypress():
                         return numeric_key_counter
                 else:
                     return None
+            elif event.type == pygame.MOUSEBUTTONDOWN:
+                pos = pygame.mouse.get_pos()
+                display_w = pygame.display.Info().current_w
+                quarter = display_w / 4
+                lastQuarter = display_w - quarter
+                if pos[0] > lastQuarter:
+                    touchResult = "next_event"
+                elif pos[0] > quarter and pos[0] < lastQuarter:
+                    touchResult = "resume_rotation"
+                else:
+                    touchResult = "pause_rotation"
+             elif event.type == pygame.MOUSEBUTTONUP:
+                return touchResult
     except pygame.error as e:
         logger.debug("Exception " + repr(e))
         exit(0)


### PR DESCRIPTION
 the width of the screen is divided in four sections, touching or clicking on the first section trigger a pause event, in the two sections in the middle trigger a resume event and in the last section, a next screen event.