### PR TITLE
addressing python-yaml deprecated loader

### DIFF
--- a/surveillance/core/util/config.py
+++ b/surveillance/core/util/config.py
@@ -1,4 +1,4 @@
 import yaml
 #Separate config.py to we can import it to be used as global config, without having it to be passed to every function/class
 with open("conf/surveillance.yml", 'r') as ymlfile:
-    cfg = yaml.load(ymlfile)
+    cfg = yaml.load(ymlfile, Loader=yaml.Loader)


### PR DESCRIPTION
If using a pyyaml version recent enough you could get an error when loading yaml config files. This is because pyyaml deprecated loading a yaml file without explicitly passing the default loader.